### PR TITLE
Automate background processing jobs

### DIFF
--- a/server/models/PON.js
+++ b/server/models/PON.js
@@ -71,7 +71,16 @@ const PONSchema = new mongoose.Schema({
     min: 0,
     max: 100,
     default: 0
-  }
+  },
+  // SLA aggregate fields
+  slaBreaches: {
+    type: Number,
+    default: 0
+  },
+  // Geofence fields for photo validation
+  centerLat: { type: Number },
+  centerLng: { type: Number },
+  geofenceRadiusM: { type: Number, default: 200 }
 }, {
   timestamps: true
 });

--- a/server/models/Task.js
+++ b/server/models/Task.js
@@ -78,10 +78,26 @@ const TaskSchema = new mongoose.Schema({
   dependencies: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Task'
-  }]
+  }],
+  // SLA fields
+  slaMinutes: {
+    type: Number,
+    min: 0
+  },
+  slaDueAt: {
+    type: Date
+  },
+  breached: {
+    type: Boolean,
+    default: false,
+    index: true
+  }
 }, {
   timestamps: true
 });
+
+// Indexes to support SLA queries
+TaskSchema.index({ slaDueAt: 1 });
 
 // Check if task can be started (dependencies completed)
 TaskSchema.methods.canStart = async function() {


### PR DESCRIPTION
Implement SLA timer fields and API logic for tasks to track performance, and add initial geofence fields to PONs for future photo validation.

This PR introduces Service Level Agreement (SLA) tracking for tasks. The `PATCH /api/tasks/:id` endpoint now automatically sets `slaDueAt` when a task moves to 'in_progress' (using default SLA minutes per task type) and flags `breached` if the task is completed late. The `GET /api/tasks` endpoint supports filtering by `breached=true` and includes a `ui.breachedBadge` flag for frontend display. Additionally, initial `centerLat`, `centerLng`, and `geofenceRadiusM` fields are added to the `PON` model to scaffold the upcoming GPS and EXIF photo validation feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-5638b81e-f6be-4d00-b610-7ca080f85ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5638b81e-f6be-4d00-b610-7ca080f85ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

