### PR TITLE
Add fiber optic network management apis

### DIFF
--- a/alembic/versions/0008_fiber_technical.py
+++ b/alembic/versions/0008_fiber_technical.py
@@ -1,0 +1,110 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0008_fiber_technical"
+down_revision = "0007_noc_core"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "splice_closures",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("pon_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("pons.id", ondelete="CASCADE")),
+        sa.Column("code", sa.String(), nullable=False, unique=True),
+        sa.Column("gps_lat", sa.Numeric(9, 6)),
+        sa.Column("gps_lng", sa.Numeric(9, 6)),
+        sa.Column("enclosure_type", sa.String()),
+        sa.Column("tray_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("status", sa.String(), server_default=sa.text("'Planned'"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("idx_splice_closures_pon", "splice_closures", ["pon_id"])
+
+    op.create_table(
+        "splice_trays",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("closure_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("splice_closures.id", ondelete="CASCADE")),
+        sa.Column("tray_no", sa.Integer(), nullable=False),
+        sa.Column("fiber_start", sa.Integer()),
+        sa.Column("fiber_end", sa.Integer()),
+        sa.Column("splices_planned", sa.Integer()),
+        sa.Column("splices_done", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.create_index("idx_splice_trays_closure", "splice_trays", ["closure_id"])
+
+    op.create_table(
+        "splices",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("tray_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("splice_trays.id", ondelete="CASCADE")),
+        sa.Column("core", sa.Integer(), nullable=False),
+        sa.Column("from_cable", sa.String()),
+        sa.Column("to_cable", sa.String()),
+        sa.Column("loss_db", sa.Numeric(5, 3)),
+        sa.Column("method", sa.String()),
+        sa.Column("tech_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id")),
+        sa.Column("time", sa.DateTime(timezone=True)),
+        sa.Column("passed", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+    )
+    op.create_index("idx_splices_tray", "splices", ["tray_id"])
+
+    op.create_table(
+        "test_plans",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("pon_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("pons.id", ondelete="CASCADE")),
+        sa.Column("link_name", sa.String(), nullable=False),
+        sa.Column("from_point", sa.String(), nullable=False),
+        sa.Column("to_point", sa.String(), nullable=False),
+        sa.Column("wavelength_nm", sa.Integer(), nullable=False),
+        sa.Column("max_loss_db", sa.Numeric(5, 2), nullable=False),
+        sa.Column("otdr_required", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("lspm_required", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("idx_test_plans_pon", "test_plans", ["pon_id"])
+
+    op.create_table(
+        "otdr_results",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("test_plan_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("test_plans.id", ondelete="CASCADE")),
+        sa.Column("file_url", sa.String(), nullable=False),
+        sa.Column("vendor", sa.String()),
+        sa.Column("wavelength_nm", sa.Integer(), nullable=False),
+        sa.Column("total_loss_db", sa.Numeric(5, 2)),
+        sa.Column("event_count", sa.Integer()),
+        sa.Column("max_splice_loss_db", sa.Numeric(5, 2)),
+        sa.Column("back_reflection_db", sa.Numeric(5, 2)),
+        sa.Column("tested_at", sa.DateTime(timezone=True)),
+        sa.Column("passed", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.create_index("idx_otdr_plan_time", "otdr_results", ["test_plan_id", "tested_at"])
+
+    op.create_table(
+        "lspm_results",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("test_plan_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("test_plans.id", ondelete="CASCADE")),
+        sa.Column("wavelength_nm", sa.Integer(), nullable=False),
+        sa.Column("measured_loss_db", sa.Numeric(5, 2), nullable=False),
+        sa.Column("margin_db", sa.Numeric(5, 2)),
+        sa.Column("tested_at", sa.DateTime(timezone=True)),
+        sa.Column("passed", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.create_index("idx_lspm_plan_time", "lspm_results", ["test_plan_id", "tested_at"])
+
+
+def downgrade():
+    op.drop_index("idx_lspm_plan_time", table_name="lspm_results")
+    op.drop_table("lspm_results")
+    op.drop_index("idx_otdr_plan_time", table_name="otdr_results")
+    op.drop_table("otdr_results")
+    op.drop_index("idx_test_plans_pon", table_name="test_plans")
+    op.drop_table("test_plans")
+    op.drop_index("idx_splices_tray", table_name="splices")
+    op.drop_table("splices")
+    op.drop_index("idx_splice_trays_closure", table_name="splice_trays")
+    op.drop_table("splice_trays")
+    op.drop_index("idx_splice_closures_pon", table_name="splice_closures")
+    op.drop_table("splice_closures")
+

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,12 @@ from app.routers import devices as devices_router
 from app.routers import incidents as incidents_router
 from app.routers import optical as optical_router
 from app.routers import nms_webhook as nms_router
+from app.routers import closures as closures_router
+from app.routers import trays as trays_router
+from app.routers import splices as splices_router
+from app.routers import tests_plans as plans_router
+from app.routers import tests_otdr as otdr_router
+from app.routers import tests_lspm as lspm_router
 from app.scheduler import init_jobs
 
 
@@ -46,6 +52,12 @@ app.include_router(photos_upload_router.router)
 app.include_router(devices_router.router)
 app.include_router(incidents_router.router)
 app.include_router(optical_router.router)
+app.include_router(closures_router.router)
+app.include_router(trays_router.router)
+app.include_router(splices_router.router)
+app.include_router(plans_router.router)
+app.include_router(otdr_router.router)
+app.include_router(lspm_router.router)
 app.include_router(nms_router.router)
 
 init_jobs()

--- a/app/routers/closures.py
+++ b/app/routers/closures.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from typing import Optional, List
+from uuid import UUID, uuid4
+from pydantic import BaseModel, Field
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/closures", tags=["closures"])
+
+
+class ClosureIn(BaseModel):
+    pon_id: UUID
+    code: str = Field(min_length=2)
+    enclosure_type: Optional[str] = None
+    gps_lat: Optional[float] = None
+    gps_lng: Optional[float] = None
+    tray_count: int = 0
+    status: str = "Planned"
+
+
+@router.post("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def create_closure(payload: ClosureIn, db: Session = Depends(get_db)):
+    sql = text(
+        """
+      insert into splice_closures (id, pon_id, code, enclosure_type, gps_lat, gps_lng, tray_count, status)
+      values (:id, :pon, :code, :type, :lat, :lng, :tc, :st)
+    """
+    )
+    cid = str(uuid4())
+    db.execute(
+        sql,
+        {
+            "id": cid,
+            "pon": str(payload.pon_id),
+            "code": payload.code,
+            "type": payload.enclosure_type,
+            "lat": payload.gps_lat,
+            "lng": payload.gps_lng,
+            "tc": payload.tray_count,
+            "st": payload.status,
+        },
+    )
+    db.commit()
+    return {"ok": True, "id": cid}
+
+
+@router.get("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_closures(pon_id: Optional[str] = Query(None), db: Session = Depends(get_db)):
+    if pon_id:
+        rows = (
+            db.execute(
+                text("select * from splice_closures where pon_id = :p order by code"),
+                {"p": pon_id},
+            )
+            .mappings()
+            .all()
+        )
+    else:
+        rows = (
+            db.execute(
+                text("select * from splice_closures order by created_at desc limit 200")
+            )
+            .mappings()
+            .all()
+        )
+    return [dict(r) for r in rows]
+
+
+class ClosurePatch(BaseModel):
+    enclosure_type: Optional[str] = None
+    gps_lat: Optional[float] = None
+    gps_lng: Optional[float] = None
+    tray_count: Optional[int] = None
+    status: Optional[str] = None
+
+
+@router.patch("/{closure_id}", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def update_closure(closure_id: str, payload: ClosurePatch, db: Session = Depends(get_db)):
+    sets: List[str] = []
+    params: dict = {"id": closure_id}
+    for k, v in payload.dict(exclude_unset=True).items():
+        sets.append(f"{k} = :{k}")
+        params[k] = v
+    if not sets:
+        raise HTTPException(400, "No fields to update")
+    db.execute(text(f"update splice_closures set {', '.join(sets)} where id = :id"), params)
+    db.commit()
+    return {"ok": True}
+

--- a/app/routers/splices.py
+++ b/app/routers/splices.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from uuid import uuid4
+from pydantic import BaseModel, Field
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/splices", tags=["splices"])
+
+
+class SpliceIn(BaseModel):
+    tray_id: str
+    core: int = Field(ge=1)
+    from_cable: str | None = None
+    to_cable: str | None = None
+    loss_db: float | None = Field(default=None, ge=0.0, le=3.0)
+    method: str | None = None
+    tech_id: str | None = None
+    passed: bool = True
+
+
+@router.post("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def add_splice(payload: SpliceIn, db: Session = Depends(get_db)):
+    sid = str(uuid4())
+    db.execute(
+        text(
+            """
+      insert into splices (id, tray_id, core, from_cable, to_cable, loss_db, method, tech_id, time, passed)
+      values (:id, :t, :c, :fc, :tc, :l, :m, :tech, now(), :p)
+    """
+        ),
+        {
+            "id": sid,
+            "t": payload.tray_id,
+            "c": payload.core,
+            "fc": payload.from_cable,
+            "tc": payload.to_cable,
+            "l": payload.loss_db,
+            "m": payload.method,
+            "tech": payload.tech_id,
+            "p": payload.passed,
+        },
+    )
+    db.execute(
+        text("update splice_trays set splices_done = coalesce(splices_done,0) + 1 where id = :t"),
+        {"t": payload.tray_id},
+    )
+    db.commit()
+    return {"ok": True, "id": sid}
+
+
+@router.get("/by-tray/{tray_id}", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_splices(tray_id: str, db: Session = Depends(get_db)):
+    rows = (
+        db.execute(text("select * from splices where tray_id = :t order by core"), {"t": tray_id})
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+
+
+class SplicePatch(BaseModel):
+    loss_db: float | None = Field(default=None, ge=0.0, le=3.0)
+    passed: bool | None = None
+    method: str | None = None
+
+
+@router.patch("/{splice_id}", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def update_splice(splice_id: str, payload: SplicePatch, db: Session = Depends(get_db)):
+    fields = payload.dict(exclude_unset=True)
+    if not fields:
+        raise HTTPException(400, "No fields")
+    sets = ", ".join([f"{k} = :{k}" for k in fields.keys()])
+    fields["id"] = splice_id
+    db.execute(text(f"update splices set {sets} where id = :id"), fields)
+    db.commit()
+    return {"ok": True}
+

--- a/app/routers/tests_lspm.py
+++ b/app/routers/tests_lspm.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from uuid import uuid4
+from pydantic import BaseModel, Field
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/tests/lspm", tags=["tests"])
+
+
+class LSPMIn(BaseModel):
+    test_plan_id: str
+    wavelength_nm: int = Field(ge=1260, le=1650)
+    measured_loss_db: float = Field(ge=0.0, le=30.0)
+    margin_db: float | None = Field(default=None, ge=-10.0, le=10.0)
+    passed: bool = False
+
+
+@router.post("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def add_lspm(payload: LSPMIn, db: Session = Depends(get_db)):
+    lid = str(uuid4())
+    db.execute(
+        text(
+            """
+      insert into lspm_results (id, test_plan_id, wavelength_nm, measured_loss_db, margin_db, tested_at, passed)
+      values (:id, :tp, :wl, :ml, :mg, now(), :p)
+    """
+        ),
+        {
+            "id": lid,
+            "tp": payload.test_plan_id,
+            "wl": payload.wavelength_nm,
+            "ml": payload.measured_loss_db,
+            "mg": payload.margin_db,
+            "p": payload.passed,
+        },
+    )
+    db.commit()
+    return {"ok": True, "id": lid}
+
+
+@router.get("/by-plan/{plan_id}", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_lspm(plan_id: str, db: Session = Depends(get_db)):
+    rows = (
+        db.execute(
+            text("select * from lspm_results where test_plan_id = :p order by tested_at desc"),
+            {"p": plan_id},
+        )
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+

--- a/app/routers/tests_otdr.py
+++ b/app/routers/tests_otdr.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from uuid import uuid4
+from pydantic import BaseModel, Field
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/tests/otdr", tags=["tests"])
+
+
+class OTDRIn(BaseModel):
+    test_plan_id: str
+    file_url: str
+    vendor: str | None = None
+    wavelength_nm: int = Field(ge=1260, le=1650)
+    total_loss_db: float | None = Field(default=None, ge=0.0, le=30.0)
+    event_count: int | None = None
+    max_splice_loss_db: float | None = Field(default=None, ge=0.0, le=5.0)
+    back_reflection_db: float | None = Field(default=None, ge=-80.0, le=-20.0)
+    passed: bool = False
+
+
+@router.post("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def add_otdr(payload: OTDRIn, db: Session = Depends(get_db)):
+    oid = str(uuid4())
+    db.execute(
+        text(
+            """
+      insert into otdr_results (id, test_plan_id, file_url, vendor, wavelength_nm, total_loss_db, event_count, max_splice_loss_db, back_reflection_db, tested_at, passed)
+      values (:id, :tp, :url, :v, :wl, :tl, :ec, :ms, :br, now(), :p)
+    """
+        ),
+        {
+            "id": oid,
+            "tp": payload.test_plan_id,
+            "url": payload.file_url,
+            "v": payload.vendor,
+            "wl": payload.wavelength_nm,
+            "tl": payload.total_loss_db,
+            "ec": payload.event_count,
+            "ms": payload.max_splice_loss_db,
+            "br": payload.back_reflection_db,
+            "p": payload.passed,
+        },
+    )
+    db.commit()
+    return {"ok": True, "id": oid}
+
+
+@router.get("/by-plan/{plan_id}", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_otdr(plan_id: str, db: Session = Depends(get_db)):
+    rows = (
+        db.execute(
+            text("select * from otdr_results where test_plan_id = :p order by tested_at desc"),
+            {"p": plan_id},
+        )
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+

--- a/app/routers/tests_plans.py
+++ b/app/routers/tests_plans.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from uuid import uuid4
+from pydantic import BaseModel, Field
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/tests/plans", tags=["tests"])
+
+
+class PlanIn(BaseModel):
+    pon_id: str
+    link_name: str
+    from_point: str
+    to_point: str
+    wavelength_nm: int = Field(ge=1260, le=1650)
+    max_loss_db: float = Field(ge=0.1, le=30.0)
+    otdr_required: bool = True
+    lspm_required: bool = True
+
+
+@router.post("", dependencies=[Depends(require_roles("ADMIN", "PM"))])
+def create_plan(payload: PlanIn, db: Session = Depends(get_db)):
+    pid = str(uuid4())
+    db.execute(
+        text(
+            """
+      insert into test_plans (id, pon_id, link_name, from_point, to_point, wavelength_nm, max_loss_db, otdr_required, lspm_required)
+      values (:id, :pon, :ln, :fp, :tp, :wl, :maxl, :ot, :ls)
+    """
+        ),
+        {
+            "id": pid,
+            "pon": payload.pon_id,
+            "ln": payload.link_name,
+            "fp": payload.from_point,
+            "tp": payload.to_point,
+            "wl": payload.wavelength_nm,
+            "maxl": payload.max_loss_db,
+            "ot": payload.otdr_required,
+            "ls": payload.lspm_required,
+        },
+    )
+    db.commit()
+    return {"ok": True, "id": pid}
+
+
+@router.get("", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_plans(pon_id: str = Query(...), db: Session = Depends(get_db)):
+    rows = (
+        db.execute(
+            text("select * from test_plans where pon_id = :p order by link_name"),
+            {"p": pon_id},
+        )
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+

--- a/app/routers/trays.py
+++ b/app/routers/trays.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from uuid import uuid4
+from pydantic import BaseModel
+from app.core.deps import get_db, require_roles
+
+
+router = APIRouter(prefix="/closures", tags=["trays"])
+
+
+class TrayIn(BaseModel):
+    tray_no: int
+    fiber_start: int | None = None
+    fiber_end: int | None = None
+    splices_planned: int | None = None
+
+
+@router.post("/{closure_id}/trays", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE"))])
+def add_tray(closure_id: str, payload: TrayIn, db: Session = Depends(get_db)):
+    tid = str(uuid4())
+    db.execute(
+        text(
+            """
+      insert into splice_trays (id, closure_id, tray_no, fiber_start, fiber_end, splices_planned)
+      values (:id, :c, :no, :fs, :fe, :sp)
+    """
+        ),
+        {
+            "id": tid,
+            "c": closure_id,
+            "no": payload.tray_no,
+            "fs": payload.fiber_start,
+            "fe": payload.fiber_end,
+            "sp": payload.splices_planned,
+        },
+    )
+    db.commit()
+    return {"ok": True, "id": tid}
+
+
+@router.get("/{closure_id}/trays", dependencies=[Depends(require_roles("ADMIN", "PM", "SITE", "AUDITOR"))])
+def list_trays(closure_id: str, db: Session = Depends(get_db)):
+    rows = (
+        db.execute(
+            text("select * from splice_trays where closure_id = :c order by tray_no"),
+            {"c": closure_id},
+        )
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+


### PR DESCRIPTION
Add database schema and API endpoints for managing fiber optic splice closures, trays, splices, and test plans/results.

---
<a href="https://cursor.com/background-agent?bcId=bc-68d96fc2-d2a8-4993-85e1-94b54245383a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68d96fc2-d2a8-4993-85e1-94b54245383a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

