### PR TITLE
Load and index Stats SA geographical data

### DIFF
--- a/scripts/import_geo.sh
+++ b/scripts/import_geo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Import Stats SA wards and suburbs shapefiles into PostGIS and run loader SQL
+
+# Required env vars:
+#   - PGHOST, PGPORT (default 5432), PGUSER, PGPASSWORD (optional if using .pgpass), PGDATABASE
+#   - WARDS_SHP: path to Wards 2021 shapefile (.shp) or datasource
+#   - SUBURBS_SHP: path to SubPlace 2011 shapefile (.shp) or datasource
+# Optional:
+#   - WARDS_LAYER (default: wards)
+#   - SUBURBS_LAYER (default: suburbs)
+
+if ! command -v ogr2ogr >/dev/null 2>&1; then
+  echo "ogr2ogr is required (GDAL). Please install GDAL." >&2
+  exit 1
+fi
+if ! command -v ogrinfo >/dev/null 2>&1; then
+  echo "ogrinfo is required (GDAL). Please install GDAL." >&2
+  exit 1
+fi
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is required. Please install PostgreSQL client tools." >&2
+  exit 1
+fi
+
+PGHOST=${PGHOST:-localhost}
+PGPORT=${PGPORT:-5432}
+PGUSER=${PGUSER:-$(whoami)}
+PGDATABASE=${PGDATABASE:-postgres}
+PGPASSWORD=${PGPASSWORD:-}
+
+if [[ -z "${WARDS_SHP:-}" || -z "${SUBURBS_SHP:-}" ]]; then
+  echo "Please set WARDS_SHP and SUBURBS_SHP environment variables to the input datasets." >&2
+  exit 1
+fi
+
+WARDS_LAYER=${WARDS_LAYER:-wards}
+SUBURBS_LAYER=${SUBURBS_LAYER:-suburbs}
+
+echo "Inspecting layers..."
+set +e
+ogrinfo -so "$WARDS_SHP" "$WARDS_LAYER" | cat
+ogrinfo -so "$SUBURBS_SHP" "$SUBURBS_LAYER" | cat
+set -e
+
+PG_CONNSTR="PG:host=${PGHOST} port=${PGPORT} user=${PGUSER} dbname=${PGDATABASE}${PGPASSWORD:+ password=${PGPASSWORD}}"
+
+echo "Ensuring PostGIS extension exists..."
+psql -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS postgis;" >/dev/null
+
+echo "Importing wards into table wards_src..."
+ogr2ogr \
+  -f PostgreSQL "$PG_CONNSTR" "$WARDS_SHP" \
+  -nln wards_src \
+  -lco GEOMETRY_NAME=wkb_geometry \
+  -lco FID=gid \
+  -nlt PROMOTE_TO_MULTI \
+  -overwrite
+
+echo "Importing suburbs into table suburbs_src..."
+ogr2ogr \
+  -f PostgreSQL "$PG_CONNSTR" "$SUBURBS_SHP" \
+  -nln suburbs_src \
+  -lco GEOMETRY_NAME=wkb_geometry \
+  -lco FID=gid \
+  -nlt PROMOTE_TO_MULTI \
+  -overwrite
+
+echo "Running SQL loader..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+psql -v ON_ERROR_STOP=1 -f "$ROOT_DIR/sql/load_geo.sql"
+
+echo "Done. Tables populated: geo_wards, geo_suburbs."
+

--- a/sql/load_geo.sql
+++ b/sql/load_geo.sql
@@ -1,0 +1,221 @@
+-- Geo loader for Stats SA wards (2021) and SubPlace (2011)
+-- Handles alternate field names and spatial join fallback
+-- Requires: PostGIS, source tables `wards_src` and `suburbs_src` loaded via ogr2ogr
+
+SET client_min_messages = WARNING;
+SET search_path = public;
+
+-- Ensure PostGIS
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Destination tables
+CREATE TABLE IF NOT EXISTS geo_wards (
+  id   text PRIMARY KEY,
+  name text,
+  geom bytea NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS geo_suburbs (
+  id      text PRIMARY KEY,
+  name    text,
+  ward_id text,
+  geom    bytea NOT NULL
+);
+
+-- Load wards
+TRUNCATE geo_wards;
+
+DO $$
+DECLARE
+  id_col   text;
+  name_col text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'wards_src'
+  ) THEN
+    RAISE EXCEPTION 'Source table % not found', 'wards_src';
+  END IF;
+
+  -- Determine ID column: prefer ward_id, then code, then wardno
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'ward_id'
+  ) THEN id_col := 'ward_id';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'code'
+  ) THEN id_col := 'code';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'wardno'
+  ) THEN id_col := 'wardno';
+  ELSE
+    RAISE EXCEPTION 'Could not determine ID column for %', 'wards_src';
+  END IF;
+
+  -- Determine NAME column: prefer ward_name, then name, else reuse id
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'ward_name'
+  ) THEN name_col := 'ward_name';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'name'
+  ) THEN name_col := 'name';
+  ELSE name_col := id_col;
+  END IF;
+
+  EXECUTE format($f$
+    INSERT INTO geo_wards(id, name, geom)
+    SELECT %1$s::text, %2$s::text, ST_AsBinary(wkb_geometry)
+    FROM wards_src
+    WHERE wkb_geometry IS NOT NULL
+  $f$, quote_ident(id_col), quote_ident(name_col));
+END $$;
+
+-- Load suburbs (SubPlace 2011), with optional spatial join to wards for ward_id
+TRUNCATE geo_suburbs;
+
+DO $$
+DECLARE
+  id_col        text;
+  name_col      text;
+  ward_col      text;
+  wards_id_col  text;
+  id_expr       text;
+  name_expr     text;
+  ward_expr     text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src'
+  ) THEN
+    RAISE EXCEPTION 'Source table % not found', 'suburbs_src';
+  END IF;
+
+  -- Determine suburb ID column: prefer sp_code, then sub_code, then code, else NULL
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'sp_code'
+  ) THEN id_col := 'sp_code';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'sub_code'
+  ) THEN id_col := 'sub_code';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'code'
+  ) THEN id_col := 'code';
+  ELSE id_col := NULL;
+  END IF;
+
+  -- Determine suburb NAME column: prefer sp_name, then sub_name, then name, else NULL
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'sp_name'
+  ) THEN name_col := 'sp_name';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'sub_name'
+  ) THEN name_col := 'sub_name';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'name'
+  ) THEN name_col := 'name';
+  ELSE name_col := NULL;
+  END IF;
+
+  -- Determine ward reference column in suburbs (if any)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'ward_id'
+  ) THEN ward_col := 'ward_id';
+  ELSIF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'suburbs_src' AND column_name = 'wardno'
+  ) THEN ward_col := 'wardno';
+  ELSE ward_col := NULL;
+  END IF;
+
+  IF ward_col IS NOT NULL THEN
+    -- Direct load when a ward reference exists in suburbs
+    id_expr := COALESCE(format('%s::text', quote_ident(id_col)), 'gid::text');
+    name_expr := CASE
+      WHEN name_col IS NOT NULL THEN format('%s::text', quote_ident(name_col))
+      WHEN id_col IS NOT NULL THEN format('%s::text', quote_ident(id_col))
+      ELSE 'gid::text'
+    END;
+    ward_expr := format('%s::text', quote_ident(ward_col));
+
+    EXECUTE format($f$
+      INSERT INTO geo_suburbs(id, name, ward_id, geom)
+      SELECT %1$s, %2$s, %3$s, ST_AsBinary(wkb_geometry)
+      FROM suburbs_src
+      WHERE wkb_geometry IS NOT NULL
+    $f$, id_expr, name_expr, ward_expr);
+  ELSE
+    -- Spatial join to wards when suburbs lack ward reference
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'wards_src'
+    ) THEN
+      RAISE EXCEPTION 'Source table % not found (required for spatial join)', 'wards_src';
+    END IF;
+
+    -- Determine wards ID column for join result
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'ward_id'
+    ) THEN wards_id_col := 'ward_id';
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'code'
+    ) THEN wards_id_col := 'code';
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'wards_src' AND column_name = 'wardno'
+    ) THEN wards_id_col := 'wardno';
+    ELSE
+      RAISE EXCEPTION 'Could not determine ID column for %', 'wards_src';
+    END IF;
+
+    id_expr := COALESCE(format('%s::text', quote_ident(id_col)), 'gid::text');
+    name_expr := CASE
+      WHEN name_col IS NOT NULL THEN format('%s::text', quote_ident(name_col))
+      WHEN id_col IS NOT NULL THEN format('%s::text', quote_ident(id_col))
+      ELSE 'gid::text'
+    END;
+
+    EXECUTE format($f$
+      WITH sub AS (
+        SELECT gid,
+               ST_CollectionExtract(wkb_geometry, 3) AS g,
+               %1$s AS sid,
+               %2$s AS sname
+        FROM suburbs_src
+      ),
+      ward AS (
+        SELECT %3$s::text AS wid, wkb_geometry
+        FROM wards_src
+      )
+      INSERT INTO geo_suburbs(id, name, ward_id, geom)
+      SELECT
+        COALESCE(sub.sid, sub.gid::text),
+        COALESCE(sub.sname, sub.sid, sub.gid::text),
+        ward.wid,
+        ST_AsBinary(ST_Multi(sub.g))
+      FROM sub
+      JOIN ward
+        ON ST_Intersects(sub.g, ward.wkb_geometry)
+      WHERE sub.g IS NOT NULL
+    $f$, id_expr, name_expr, quote_ident(wards_id_col));
+  END IF;
+END $$;
+
+-- Indexes
+DROP INDEX IF EXISTS idx_geo_wards_geom;
+CREATE INDEX idx_geo_wards_geom ON geo_wards USING GIST (ST_GeomFromWKB(geom));
+DROP INDEX IF EXISTS idx_geo_suburbs_geom;
+CREATE INDEX idx_geo_suburbs_geom ON geo_suburbs USING GIST (ST_GeomFromWKB(geom));
+


### PR DESCRIPTION
Implement a flexible PostGIS loader for Stats SA wards and suburbs, accommodating diverse field names and spatially joining suburbs to wards when `ward_id` is absent.

---
<a href="https://cursor.com/background-agent?bcId=bc-05ff09f3-4c22-4b65-8482-2e58972dc227">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05ff09f3-4c22-4b65-8482-2e58972dc227">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

