### PR TITLE
Load and index Stats SA geographical data

### DIFF
--- a/scripts/import_sa_geographies.sh
+++ b/scripts/import_sa_geographies.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Import Stats SA Wards (2021) and SubPlace (2011) shapefiles
+# into staging tables (wards_src, suburbs_src) and run loader SQL
+
+# Usage:
+#   ./scripts/import_sa_geographies.sh \
+#     --pg "postgresql://user:pass@localhost:5432/dbname" \
+#     --wards /path/to/wards.shp \
+#     --suburbs /path/to/suburbs.shp
+
+PG_DSN=""
+WARDS_SHP=""
+SUBURBS_SHP=""
+SCHEMA="public"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pg)
+      PG_DSN="$2"; shift 2 ;;
+    --wards)
+      WARDS_SHP="$2"; shift 2 ;;
+    --suburbs)
+      SUBURBS_SHP="$2"; shift 2 ;;
+    --schema)
+      SCHEMA="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '1,30p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$PG_DSN" || -z "$WARDS_SHP" || -z "$SUBURBS_SHP" ]]; then
+  echo "Missing required args. See --help" >&2
+  exit 1
+fi
+
+echo "Creating/clearing staging tables..."
+psql "$PG_DSN" -v ON_ERROR_STOP=1 -c "
+  CREATE EXTENSION IF NOT EXISTS postgis;
+  DROP TABLE IF EXISTS ${SCHEMA}.wards_src;
+  DROP TABLE IF EXISTS ${SCHEMA}.suburbs_src;
+  -- Create empty tables with geometry type inferred via ogr2ogr
+  CREATE TABLE ${SCHEMA}.wards_src (dummy int);
+  DROP TABLE ${SCHEMA}.wards_src;
+  CREATE TABLE ${SCHEMA}.suburbs_src (dummy int);
+  DROP TABLE ${SCHEMA}.suburbs_src;
+"
+
+echo "Importing wards shapefile: $WARDS_SHP"
+ogr2ogr -f PostgreSQL \
+  PG:"$PG_DSN" \
+  "$WARDS_SHP" \
+  -nln "${SCHEMA}.wards_src" \
+  -lco GEOMETRY_NAME=wkb_geometry \
+  -lco FID=gid \
+  -nlt PROMOTE_TO_MULTI \
+  -skipfailures \
+  -overwrite
+
+echo "Importing suburbs shapefile: $SUBURBS_SHP"
+ogr2ogr -f PostgreSQL \
+  PG:"$PG_DSN" \
+  "$SUBURBS_SHP" \
+  -nln "${SCHEMA}.suburbs_src" \
+  -lco GEOMETRY_NAME=wkb_geometry \
+  -lco FID=gid \
+  -nlt PROMOTE_TO_MULTI \
+  -skipfailures \
+  -overwrite
+
+echo "Running loader SQL..."
+psql "$PG_DSN" -v ON_ERROR_STOP=1 -f "/workspace/sql/load_sa_geographies.sql"
+
+echo "Done. Counts:"
+psql "$PG_DSN" -v ON_ERROR_STOP=1 -c "
+  SELECT 'geo_wards' AS table, COUNT(*) FROM ${SCHEMA}.geo_wards
+  UNION ALL
+  SELECT 'geo_suburbs' AS table, COUNT(*) FROM ${SCHEMA}.geo_suburbs;
+"
+

--- a/sql/load_sa_geographies.sql
+++ b/sql/load_sa_geographies.sql
@@ -1,0 +1,259 @@
+-- Stats SA wards (2021) and SubPlaces (2011) loader
+-- Idempotent script that:
+-- 1) Creates target tables if needed
+-- 2) Loads wards from staging `wards_src` handling common field variants
+-- 3) Loads suburbs from staging `suburbs_src` using direct mapping if `WARD_ID` exists,
+--    otherwise spatially joins to wards; handles common field variants
+-- 4) Creates spatial indexes on decoded WKB geometries
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Target tables
+CREATE TABLE IF NOT EXISTS geo_wards (
+  id   text PRIMARY KEY,
+  name text NOT NULL,
+  geom bytea NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS geo_suburbs (
+  id      text PRIMARY KEY,
+  name    text NOT NULL,
+  ward_id text,
+  geom    bytea NOT NULL
+);
+
+-- Ensure staging tables exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='wards_src'
+  ) THEN
+    RAISE EXCEPTION 'Missing source table: wards_src';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='suburbs_src'
+  ) THEN
+    RAISE EXCEPTION 'Missing source table: suburbs_src';
+  END IF;
+END $$;
+
+-- Load wards (handle multiple field variants)
+DO $$
+DECLARE
+  has_ward_id  boolean;
+  has_ward_name boolean;
+  has_code     boolean;
+  has_name     boolean;
+  has_wardno   boolean;
+BEGIN
+  TRUNCATE TABLE geo_wards;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='wards_src' AND column_name='ward_id'
+  ) INTO has_ward_id;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='wards_src' AND column_name='ward_name'
+  ) INTO has_ward_name;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='wards_src' AND column_name='code'
+  ) INTO has_code;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='wards_src' AND column_name='name'
+  ) INTO has_name;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='wards_src' AND column_name='wardno'
+  ) INTO has_wardno;
+
+  IF has_ward_id AND has_ward_name THEN
+    EXECUTE $q$
+      INSERT INTO geo_wards(id, name, geom)
+      SELECT WARD_ID::text, WARD_NAME::text, ST_AsBinary(wkb_geometry)
+      FROM wards_src
+      WHERE wkb_geometry IS NOT NULL
+    $q$;
+  ELSIF has_code AND has_name THEN
+    EXECUTE $q$
+      INSERT INTO geo_wards(id, name, geom)
+      SELECT CODE::text, NAME::text, ST_AsBinary(wkb_geometry)
+      FROM wards_src
+      WHERE wkb_geometry IS NOT NULL
+    $q$;
+  ELSIF has_wardno AND has_name THEN
+    EXECUTE $q$
+      INSERT INTO geo_wards(id, name, geom)
+      SELECT WARDNO::text, NAME::text, ST_AsBinary(wkb_geometry)
+      FROM wards_src
+      WHERE wkb_geometry IS NOT NULL
+    $q$;
+  ELSE
+    RAISE EXCEPTION 'Unable to determine ward id/name columns in wards_src. Expected one of: (WARD_ID, WARD_NAME) or (CODE, NAME) or (WARDNO, NAME).';
+  END IF;
+END $$;
+
+-- Load suburbs; direct if WARD_ID present on suburbs, otherwise spatial join to wards
+DO $$
+DECLARE
+  has_sp_code     boolean;
+  has_sp_name     boolean;
+  has_sub_code    boolean;
+  has_sub_name    boolean;
+  has_name        boolean;
+  has_sub_ward_id boolean;
+  ward_id_col     text;
+  sub_id_expr     text;
+  sub_name_expr   text;
+BEGIN
+  TRUNCATE TABLE geo_suburbs;
+
+  -- suburb-side columns
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='sp_code'
+  ) INTO has_sp_code;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='sp_name'
+  ) INTO has_sp_name;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='sub_code'
+  ) INTO has_sub_code;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='sub_name'
+  ) INTO has_sub_name;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='name'
+  ) INTO has_name;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='suburbs_src' AND column_name='ward_id'
+  ) INTO has_sub_ward_id;
+
+  -- prefer existing ward_id on suburbs
+  IF has_sub_ward_id THEN
+    IF has_sp_code AND has_sp_name THEN
+      EXECUTE $q$
+        INSERT INTO geo_suburbs(id, name, ward_id, geom)
+        SELECT SP_CODE::text, SP_NAME::text, WARD_ID::text, ST_AsBinary(wkb_geometry)
+        FROM suburbs_src
+        WHERE wkb_geometry IS NOT NULL
+      $q$;
+    ELSIF has_sub_code AND has_sub_name THEN
+      EXECUTE $q$
+        INSERT INTO geo_suburbs(id, name, ward_id, geom)
+        SELECT SUB_CODE::text, SUB_NAME::text, WARD_ID::text, ST_AsBinary(wkb_geometry)
+        FROM suburbs_src
+        WHERE wkb_geometry IS NOT NULL
+      $q$;
+    ELSE
+      -- fallback mapping using best-available id/name columns
+      sub_id_expr := CASE
+        WHEN has_sp_code THEN 'SP_CODE::text'
+        WHEN has_sub_code THEN 'SUB_CODE::text'
+        ELSE 'gid::text'
+      END;
+
+      sub_name_expr := CASE
+        WHEN has_sp_name THEN 'SP_NAME::text'
+        WHEN has_sub_name THEN 'SUB_NAME::text'
+        WHEN has_name THEN 'NAME::text'
+        ELSE 'gid::text'
+      END;
+
+      EXECUTE format($q$
+        INSERT INTO geo_suburbs(id, name, ward_id, geom)
+        SELECT %s, %s, WARD_ID::text, ST_AsBinary(wkb_geometry)
+        FROM suburbs_src
+        WHERE wkb_geometry IS NOT NULL
+      $q$, sub_id_expr, sub_name_expr);
+    END IF;
+
+  ELSE
+    -- Spatial join fallback: pick ward id column variant
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wards_src' AND column_name='ward_id'
+    ) THEN
+      ward_id_col := 'WARD_ID';
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wards_src' AND column_name='code'
+    ) THEN
+      ward_id_col := 'CODE';
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wards_src' AND column_name='wardno'
+    ) THEN
+      ward_id_col := 'WARDNO';
+    ELSE
+      RAISE EXCEPTION 'Unable to determine ward id column in wards_src for spatial join.';
+    END IF;
+
+    sub_id_expr := CASE
+      WHEN has_sp_code THEN 'SP_CODE::text'
+      WHEN has_sub_code THEN 'SUB_CODE::text'
+      ELSE 'gid::text'
+    END;
+
+    sub_name_expr := CASE
+      WHEN has_sp_name THEN 'SP_NAME::text'
+      WHEN has_sub_name THEN 'SUB_NAME::text'
+      WHEN has_name THEN 'NAME::text'
+      ELSE 'gid::text'
+    END;
+
+    EXECUTE format($q$
+      WITH sub AS (
+        SELECT
+          gid,
+          %s AS sid,
+          %s AS sname,
+          ST_Multi(ST_CollectionExtract(ST_MakeValid(wkb_geometry), 3)) AS g
+        FROM suburbs_src
+      ),
+      ward AS (
+        SELECT
+          %I::text AS wid,
+          ST_Multi(ST_CollectionExtract(ST_MakeValid(wkb_geometry), 3)) AS g
+        FROM wards_src
+      )
+      INSERT INTO geo_suburbs(id, name, ward_id, geom)
+      SELECT
+        COALESCE(sub.sid, sub.gid::text),
+        COALESCE(sub.sname, sub.gid::text),
+        ward.wid,
+        ST_AsBinary(sub.g)
+      FROM sub
+      JOIN ward
+        ON ST_Intersects(sub.g, ward.g)
+      WHERE sub.g IS NOT NULL
+    $q$, sub_id_expr, sub_name_expr, ward_id_col);
+  END IF;
+END $$;
+
+-- Spatial indexes on decoded geometries
+DROP INDEX IF EXISTS idx_geo_wards_geom;
+CREATE INDEX idx_geo_wards_geom ON geo_wards USING GIST (ST_GeomFromWKB(geom));
+
+DROP INDEX IF EXISTS idx_geo_suburbs_geom;
+CREATE INDEX idx_geo_suburbs_geom ON geo_suburbs USING GIST (ST_GeomFromWKB(geom));
+


### PR DESCRIPTION
Add a robust, idempotent loader for Stats SA wards and suburbs, handling common field name variants and spatial-join fallback for missing ward IDs.

This loader provides flexibility for different source shapefile schemas by dynamically detecting ID and name columns for both wards and suburbs. It also ensures data integrity by spatially joining suburbs to wards when the `WARD_ID` is not directly available in the suburbs source data.

---
<a href="https://cursor.com/background-agent?bcId=bc-88c0041b-e524-4849-bb6b-ee802dcc30be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88c0041b-e524-4849-bb6b-ee802dcc30be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

