### PR TITLE
Load and verify geographical data

### DIFF
--- a/scripts/load_geo.sh
+++ b/scripts/load_geo.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf "[%s] %s\n" "$(date +'%Y-%m-%dT%H:%M:%S')" "$*"; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+
+# Ensure required tools are available
+require_cmd psql
+require_cmd ogr2ogr
+
+DATABASE_URL="${DATABASE_URL:-}"
+if [ -z "$DATABASE_URL" ]; then
+  echo "Error: DATABASE_URL is not set. Example: export DATABASE_URL=\"postgresql://app:app@localhost:5432/app\"" >&2
+  exit 1
+fi
+
+# Optional overrides from environment
+WARDS_SHP="${WARDS_SHP:-/workspace/data/za_wards/wards.shp}"
+SUBURBS_SHP="${SUBURBS_SHP:-/workspace/data/za_suburbs/suburbs.shp}"
+
+wait_for_db() {
+  local max_tries=30
+  local i
+  for i in $(seq 1 "$max_tries"); do
+    if psql "$DATABASE_URL" -tAc 'select 1' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+log "Waiting for database availability..."
+if ! wait_for_db; then
+  echo "Error: could not connect to database at DATABASE_URL after waiting." >&2
+  exit 1
+fi
+
+log "Ensuring PostGIS extension exists (no-op if already installed)"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS postgis;" | cat
+
+log "Ensuring optional schema tables exist (geo_wards, geo_suburbs)"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "/workspace/sql/schema_optional.sql" | cat
+
+run_ogr() {
+  local shp="$1"
+  local layer_name="$2"
+  if [ -f "$shp" ]; then
+    log "Loading $shp into table $layer_name via ogr2ogr (EPSG:4326)"
+    ogr2ogr -f "PostgreSQL" \
+      PG:"$DATABASE_URL" "$shp" \
+      -nln "$layer_name" \
+      -t_srs EPSG:4326 \
+      -nlt PROMOTE_TO_MULTI \
+      -lco GEOMETRY_NAME=geom \
+      -overwrite | cat
+  else
+    log "Skipping $layer_name load: shapefile not found at $shp"
+  fi
+}
+
+run_ogr "$WARDS_SHP" "wards_src"
+run_ogr "$SUBURBS_SHP" "suburbs_src"
+
+# Only run geo load mapping if staging tables exist
+have_wards_src=$(psql "$DATABASE_URL" -Atc "select coalesce(to_regclass('public.wards_src')::text,'')")
+have_suburbs_src=$(psql "$DATABASE_URL" -Atc "select coalesce(to_regclass('public.suburbs_src')::text,'')")
+
+if [ -n "$have_wards_src" ] || [ -n "$have_suburbs_src" ]; then
+  log "Populating geo_wards and geo_suburbs from staging"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "/workspace/sql/geo_load.sql" | cat
+else
+  log "Skipping geo table population: no staging tables present"
+fi
+
+log "Running backfill of geometry JSON and PON geofences (safe, conditional)"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "/workspace/sql/backfill_geoms.sql" | cat
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "/workspace/sql/pons_geofence.sql" | cat
+
+log "Running sanity checks"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=0 -f "/workspace/sql/sanity_checks.sql" | cat
+
+log "Done"
+

--- a/sql/backfill_geoms.sql
+++ b/sql/backfill_geoms.sql
@@ -1,0 +1,109 @@
+-- Backfill geometry JSON across various tables, conditionally.
+-- This script is idempotent and skips steps if tables/columns are missing.
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Allow caller to set a projected SRID for easting/northing via a GUC.
+-- Example: psql "$DATABASE_URL" -c "set app.srid='2054';" -f backfill_geoms.sql
+-- Defaults to 2054 if not provided.
+DO $$ BEGIN PERFORM set_config('app.srid', current_setting('app.srid', true), true); EXCEPTION WHEN others THEN NULL; END $$;
+
+-- Helper to fetch SRID from GUC or fallback
+CREATE OR REPLACE FUNCTION public._get_app_srid() RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE v integer; BEGIN v := COALESCE(NULLIF(current_setting('app.srid', true), '')::int, 2054); RETURN v; END $$;
+
+-- Poles: lat/lng -> geom_geojson
+DO $$
+BEGIN
+  IF to_regclass('public.poles') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='poles' AND column_name='geom_geojson') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='poles' AND column_name='gps_lat')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='poles' AND column_name='gps_lng') THEN
+      EXECUTE $$
+        UPDATE public.poles
+        SET geom_geojson = ST_AsGeoJSON(ST_SetSRID(ST_MakePoint(gps_lng, gps_lat), 4326))::jsonb
+        WHERE geom_geojson IS NULL AND gps_lat IS NOT NULL AND gps_lng IS NOT NULL;$$;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='poles' AND column_name='easting')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='poles' AND column_name='northing') THEN
+      EXECUTE format(
+        $$UPDATE public.poles
+          SET geom_geojson = ST_AsGeoJSON(
+            ST_Transform(ST_SetSRID(ST_MakePoint(easting, northing), %s), 4326)
+          )::jsonb
+          WHERE geom_geojson IS NULL AND easting IS NOT NULL AND northing IS NOT NULL;$$,
+        public._get_app_srid()
+      );
+    END IF;
+  END IF;
+END$$;
+
+-- Closures: lat/lng and projected variants
+DO $$
+BEGIN
+  IF to_regclass('public.closures') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='closures' AND column_name='geom_geojson') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='closures' AND column_name='gps_lat')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='closures' AND column_name='gps_lng') THEN
+      EXECUTE $$
+        UPDATE public.closures
+        SET geom_geojson = ST_AsGeoJSON(ST_SetSRID(ST_MakePoint(gps_lng, gps_lat), 4326))::jsonb
+        WHERE geom_geojson IS NULL AND gps_lat IS NOT NULL AND gps_lng IS NOT NULL;$$;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='closures' AND column_name='easting')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='closures' AND column_name='northing') THEN
+      EXECUTE format(
+        $$UPDATE public.closures
+          SET geom_geojson = ST_AsGeoJSON(
+            ST_Transform(ST_SetSRID(ST_MakePoint(easting, northing), %s), 4326)
+          )::jsonb
+          WHERE geom_geojson IS NULL AND easting IS NOT NULL AND northing IS NOT NULL;$$,
+        public._get_app_srid()
+      );
+    END IF;
+  END IF;
+END$$;
+
+-- Cable register: WKT path -> geom_geojson
+DO $$
+BEGIN
+  IF to_regclass('public.cable_register') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_register' AND column_name='geom_geojson') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_register' AND column_name='path_wkt') THEN
+      EXECUTE $$
+        UPDATE public.cable_register
+          SET geom_geojson = ST_AsGeoJSON(ST_SetSRID(ST_GeomFromText(path_wkt), 4326))::jsonb
+          WHERE geom_geojson IS NULL AND path_wkt IS NOT NULL;$$;
+    END IF;
+  END IF;
+END$$;
+
+-- Cable register: build lines from points table cable_points(cable_id, seq, lng, lat)
+DO $$
+BEGIN
+  IF to_regclass('public.cable_points') IS NOT NULL
+     AND to_regclass('public.cable_register') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_points' AND column_name='cable_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_points' AND column_name='seq')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_points' AND column_name='lng')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_points' AND column_name='lat')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='cable_register' AND column_name='geom_geojson') THEN
+    EXECUTE $$
+      WITH lines AS (
+        SELECT cable_id,
+               ST_MakeLine(ST_SetSRID(ST_MakePoint(lng, lat),4326) ORDER BY seq) AS geom
+        FROM public.cable_points
+        GROUP BY cable_id
+      )
+      UPDATE public.cable_register c
+      SET geom_geojson = ST_AsGeoJSON(l.geom)::jsonb
+      FROM lines l
+      WHERE c.id = l.cable_id AND c.geom_geojson IS NULL;$$;
+  END IF;
+END$$;
+
+-- Cleanup helper function (optional to keep)
+-- DROP FUNCTION public._get_app_srid();
+

--- a/sql/geo_load.sql
+++ b/sql/geo_load.sql
@@ -1,0 +1,67 @@
+-- Ensure PostGIS is available
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Insert Wards
+DO $$
+DECLARE
+  have_target boolean := (to_regclass('public.geo_wards') IS NOT NULL);
+  have_src    boolean := (to_regclass('public.wards_src') IS NOT NULL);
+BEGIN
+  IF have_target AND have_src THEN
+    EXECUTE $$TRUNCATE public.geo_wards;$$;
+    EXECUTE $$
+      INSERT INTO public.geo_wards(id, name, geom)
+      SELECT
+        COALESCE(
+          to_jsonb(ws)->>'ward_id',
+          to_jsonb(ws)->>'code',
+          to_jsonb(ws)->>'gid'
+        ) AS id,
+        COALESCE(
+          to_jsonb(ws)->>'ward_name',
+          to_jsonb(ws)->>'name',
+          to_jsonb(ws)->>'descr'
+        ) AS name,
+        ST_AsBinary(ws.geom) AS geom
+      FROM public.wards_src ws
+      WHERE ws.geom IS NOT NULL;$$;
+
+    -- Index for performance
+    EXECUTE $$DROP INDEX IF EXISTS public.idx_geo_wards_geom;$$;
+    EXECUTE $$CREATE INDEX idx_geo_wards_geom ON public.geo_wards USING GIST (ST_GeomFromWKB(geom));$$;
+  END IF;
+END$$;
+
+-- Insert Suburbs
+DO $$
+DECLARE
+  have_target boolean := (to_regclass('public.geo_suburbs') IS NOT NULL);
+  have_src    boolean := (to_regclass('public.suburbs_src') IS NOT NULL);
+BEGIN
+  IF have_target AND have_src THEN
+    EXECUTE $$TRUNCATE public.geo_suburbs;$$;
+    EXECUTE $$
+      INSERT INTO public.geo_suburbs(id, name, ward_id, geom)
+      SELECT
+        COALESCE(
+          to_jsonb(ss)->>'suburb_id',
+          to_jsonb(ss)->>'gid'
+        ) AS id,
+        COALESCE(
+          to_jsonb(ss)->>'suburb',
+          to_jsonb(ss)->>'name'
+        ) AS name,
+        COALESCE(
+          to_jsonb(ss)->>'ward_id',
+          to_jsonb(ss)->>'wardcode'
+        ) AS ward_id,
+        ST_AsBinary(ss.geom) AS geom
+      FROM public.suburbs_src ss
+      WHERE ss.geom IS NOT NULL;$$;
+
+    -- Index for performance
+    EXECUTE $$DROP INDEX IF EXISTS public.idx_geo_suburbs_geom;$$;
+    EXECUTE $$CREATE INDEX idx_geo_suburbs_geom ON public.geo_suburbs USING GIST (ST_GeomFromWKB(geom));$$;
+  END IF;
+END$$;
+

--- a/sql/pons_geofence.sql
+++ b/sql/pons_geofence.sql
@@ -1,0 +1,45 @@
+-- Add geofence to existing PONs where possible.
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Option A: center and radius_m columns present
+DO $$
+BEGIN
+  IF to_regclass('public.pons') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='pons' AND column_name='geofence') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='pons' AND column_name='center_lat')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='pons' AND column_name='center_lng')
+       AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='pons' AND column_name='radius_m') THEN
+      EXECUTE $$
+        UPDATE public.pons
+        SET geofence = ST_AsGeoJSON(
+          ST_Transform(
+            ST_Buffer(
+              ST_SetSRID(ST_MakePoint(center_lng, center_lat), 4326)::geography,
+              radius_m
+            )::geometry, 4326)
+        )::jsonb
+        WHERE geofence IS NULL AND center_lat IS NOT NULL AND center_lng IS NOT NULL AND radius_m IS NOT NULL;$$;
+    END IF;
+
+    -- Option B: boundary_wkt column present
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='pons' AND column_name='boundary_wkt') THEN
+      EXECUTE $$
+        UPDATE public.pons
+        SET geofence = ST_AsGeoJSON(ST_SetSRID(ST_GeomFromText(boundary_wkt), 4326))::jsonb
+        WHERE geofence IS NULL AND boundary_wkt IS NOT NULL;$$;
+    END IF;
+
+    -- Optional simplify for lighter map payloads
+    EXECUTE $$
+      UPDATE public.pons
+      SET geofence = ST_AsGeoJSON(
+        ST_SimplifyPreserveTopology(
+          ST_SetSRID(ST_GeomFromGeoJSON(geofence::text),4326),
+          0.0001
+        )
+      )::jsonb
+      WHERE geofence IS NOT NULL;$$;
+  END IF;
+END$$;
+

--- a/sql/sanity_checks.sql
+++ b/sql/sanity_checks.sql
@@ -1,0 +1,22 @@
+-- Sanity checks. Some queries may require tables to exist.
+
+-- Counts
+SELECT count(*) AS wards FROM geo_wards;
+SELECT count(*) AS suburbs FROM geo_suburbs;
+SELECT count(*) AS poles_geo FROM poles WHERE geom_geojson IS NOT NULL;
+SELECT count(*) AS closures_geo FROM closures WHERE geom_geojson IS NOT NULL;
+SELECT count(*) AS cables_geo FROM cable_register WHERE geom_geojson IS NOT NULL;
+SELECT count(*) AS pons_geo FROM pons WHERE geofence IS NOT NULL;
+
+-- Validate geometry
+SELECT id FROM geo_wards WHERE ST_IsValid(ST_GeomFromWKB(geom)) = false LIMIT 10;
+SELECT id FROM geo_suburbs WHERE ST_IsValid(ST_GeomFromWKB(geom)) = false LIMIT 10;
+
+-- Optional: Photo geofence test on 20 random photos (requires v_photos, v_pons, photos views)
+-- SELECT ph.id, ST_Contains(vp.geofence_geom, vp2.gps_geom) AS inside
+-- FROM v_photos vp2
+-- JOIN v_pons vp ON vp.id = vp2.pon_id
+-- JOIN photos ph ON ph.id = vp2.id
+-- WHERE vp2.gps_geom IS NOT NULL AND vp.geofence_geom IS NOT NULL
+-- LIMIT 20;
+

--- a/sql/schema_optional.sql
+++ b/sql/schema_optional.sql
@@ -1,0 +1,22 @@
+-- Optional schema creation: creates geo_wards and geo_suburbs if missing.
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+DO $$
+BEGIN
+  IF to_regclass('public.geo_wards') IS NULL THEN
+    CREATE TABLE public.geo_wards (
+      id   text,
+      name text,
+      geom bytea
+    );
+  END IF;
+  IF to_regclass('public.geo_suburbs') IS NULL THEN
+    CREATE TABLE public.geo_suburbs (
+      id      text,
+      name    text,
+      ward_id text,
+      geom    bytea
+    );
+  END IF;
+END$$;
+


### PR DESCRIPTION
Add scripts and SQL to load geographic data, backfill asset geometries, and create PON geofences.

This provides a robust, idempotent, and conditional workflow for managing geographic data in a PostGIS database, addressing the user's request for loading SA wards/suburbs, backfilling existing asset geometries (poles, closures, cables), and adding PON geofences. The scripts are designed to be resilient to missing tables, columns, and shapefiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b51d09a-d54b-4e02-a20a-8d6f4b30913e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b51d09a-d54b-4e02-a20a-8d6f4b30913e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

