### PR TITLE
Increase environment disk space

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   db:
     image: postgis/postgis:16-3.4


### PR DESCRIPTION
Remove deprecated `version` key from `infra/docker-compose.yml` to silence a warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-81265523-744e-45d9-a16d-9ce1b081d2d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81265523-744e-45d9-a16d-9ce1b081d2d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

