### PR TITLE
Troubleshoot function invocation failures

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,6 +23,12 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg2://app:app@db:5432/app
       CORS_ALLOW_ORIGINS: http://localhost:3000
+      REDIS_URL: redis://redis:6379/0
+      S3_ENDPOINT: http://minio:9000
+      S3_REGION: us-east-1
+      S3_BUCKET: fiber-photos
+      S3_ACCESS_KEY: minio
+      S3_SECRET_KEY: minio12345
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
Add Redis and S3 environment variables to the API service in docker-compose to enable local service connectivity and resolve `FUNCTION_INVOCATION_FAILED` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c555e6a-a465-4023-a1b6-6881e367880f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c555e6a-a465-4023-a1b6-6881e367880f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

