### PR TITLE
Update legacy jwt secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+.env
+.env.*
+node_modules/
+.venv/
+__pycache__/
+dist/
+build/
+*.log
 node_modules/
 .env
 uploads/

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ export $(cat .env.staging | xargs) && python scripts/setup_minio.py
 
 - `NODE_ENV=production`
 - `MONGODB_URI` (production database)
-- `JWT_SECRET` (strong secret key)
+- `JWT_SECRET` (strong secret key). Supports raw UTF-8 or base64-encoded values. To force base64 decoding, set `JWT_SECRET_BASE64=true` or `JWT_SECRET_ENCODING=base64`.
 
 ## Configuration & Environment
 
@@ -196,9 +196,11 @@ Key environment variables (see also `docs/secrets.md`):
   - `DATABASE_URL` (e.g., `postgresql+psycopg2://app:app@localhost:5432/app`)
   - `CORS_ALLOW_ORIGINS` (comma-separated list or `*`)
   - `S3_ENDPOINT`, `S3_REGION`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`
+  - `JWT_SECRET` (supports base64 via `JWT_SECRET_BASE64=true` or `JWT_SECRET_ENCODING=base64`)
 
 - Legacy API (Express)
   - `MONGODB_URI`, `JWT_SECRET`, `PORT` (default 5000)
+  - Optional: `JWT_SECRET_BASE64=true` or `JWT_SECRET_ENCODING=base64` when the secret is base64
   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `MAIL_FROM`
   - `DISABLE_SLA_MONITOR`, `SLA_MONITOR_INTERVAL_MS`
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const { getJwtSecret } = require('../utils/jwtSecret');
 
 const auth = async (req, res, next) => {
   const token = req.header('x-auth-token') || req.header('Authorization')?.replace('Bearer ', '');
@@ -9,7 +10,7 @@ const auth = async (req, res, next) => {
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret');
+    const decoded = jwt.verify(token, getJwtSecret());
     const user = await User.findById(decoded.user.id).select('-password');
     
     if (!user || !user.isActive) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const { getJwtSecret } = require('../utils/jwtSecret');
 const { body, validationResult } = require('express-validator');
 const User = require('../models/User');
 const { auth } = require('../middleware/auth');
@@ -50,7 +51,7 @@ router.post('/register', [
 
     jwt.sign(
       payload,
-      process.env.JWT_SECRET || 'fallback_secret',
+      getJwtSecret(),
       { expiresIn: '24h' },
       (err, token) => {
         if (err) throw err;
@@ -117,7 +118,7 @@ router.post('/login', [
 
     jwt.sign(
       payload,
-      process.env.JWT_SECRET || 'fallback_secret',
+      getJwtSecret(),
       { expiresIn: '24h' },
       (err, token) => {
         if (err) throw err;

--- a/server/utils/jwtSecret.js
+++ b/server/utils/jwtSecret.js
@@ -1,0 +1,40 @@
+function isTruthy(value) {
+  if (!value) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'y';
+}
+
+function looksLikeBase64(value) {
+  if (!value) return false;
+  // Base64 characters plus optional padding '=' characters
+  // Also allow '/' and '+' which are common in base64
+  const base64Regex = /^[A-Za-z0-9+/]+={0,2}$/;
+  // Heuristic: length should be a multiple of 4 for standard base64
+  return value.length % 4 === 0 && base64Regex.test(value);
+}
+
+function getJwtSecret() {
+  const rawSecret = process.env.JWT_SECRET;
+  if (!rawSecret) {
+    throw new Error('Server not configured: JWT_SECRET is missing');
+  }
+
+  const encoding = (process.env.JWT_SECRET_ENCODING || '').trim().toLowerCase();
+  const isBase64Flag = isTruthy(process.env.JWT_SECRET_BASE64);
+
+  const shouldDecodeBase64 = isBase64Flag || encoding === 'base64' || looksLikeBase64(rawSecret);
+
+  if (shouldDecodeBase64) {
+    try {
+      return Buffer.from(rawSecret, 'base64');
+    } catch (err) {
+      throw new Error('Invalid base64 JWT secret provided');
+    }
+  }
+
+  // Return as Buffer for consistent handling by jsonwebtoken
+  return Buffer.from(rawSecret, 'utf8');
+}
+
+module.exports = { getJwtSecret };
+

--- a/supabase/functions/node-express/middleware/auth.js
+++ b/supabase/functions/node-express/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const { getJwtSecret } = require('../utils/jwtSecret');
 
 const auth = async (req, res, next) => {
   const token = req.header('x-auth-token') || req.header('Authorization')?.replace('Bearer ', '');
@@ -9,7 +10,7 @@ const auth = async (req, res, next) => {
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret');
+    const decoded = jwt.verify(token, getJwtSecret());
     const user = await User.findById(decoded.user.id).select('-password');
     
     if (!user || !user.isActive) {

--- a/supabase/functions/node-express/routes/auth.js
+++ b/supabase/functions/node-express/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const { getJwtSecret } = require('../utils/jwtSecret');
 const { body, validationResult } = require('express-validator');
 const User = require('../models/User');
 const { auth } = require('../middleware/auth');
@@ -50,7 +51,7 @@ router.post('/register', [
 
     jwt.sign(
       payload,
-      process.env.JWT_SECRET || 'fallback_secret',
+      getJwtSecret(),
       { expiresIn: '24h' },
       (err, token) => {
         if (err) throw err;
@@ -117,7 +118,7 @@ router.post('/login', [
 
     jwt.sign(
       payload,
-      process.env.JWT_SECRET || 'fallback_secret',
+      getJwtSecret(),
       { expiresIn: '24h' },
       (err, token) => {
         if (err) throw err;

--- a/supabase/functions/node-express/utils/jwtSecret.js
+++ b/supabase/functions/node-express/utils/jwtSecret.js
@@ -1,0 +1,36 @@
+function isTruthy(value) {
+  if (!value) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'y';
+}
+
+function looksLikeBase64(value) {
+  if (!value) return false;
+  const base64Regex = /^[A-Za-z0-9+/]+={0,2}$/;
+  return value.length % 4 === 0 && base64Regex.test(value);
+}
+
+function getJwtSecret() {
+  const rawSecret = process.env.JWT_SECRET;
+  if (!rawSecret) {
+    throw new Error('Server not configured: JWT_SECRET is missing');
+  }
+
+  const encoding = (process.env.JWT_SECRET_ENCODING || '').trim().toLowerCase();
+  const isBase64Flag = isTruthy(process.env.JWT_SECRET_BASE64);
+
+  const shouldDecodeBase64 = isBase64Flag || encoding === 'base64' || looksLikeBase64(rawSecret);
+
+  if (shouldDecodeBase64) {
+    try {
+      return Buffer.from(rawSecret, 'base64');
+    } catch (err) {
+      throw new Error('Invalid base64 JWT secret provided');
+    }
+  }
+
+  return Buffer.from(rawSecret, 'utf8');
+}
+
+module.exports = { getJwtSecret };
+


### PR DESCRIPTION
Add base64-aware JWT secret loaders and refactor usage to support legacy secrets and remove insecure fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-65f6ab08-cf74-4e52-9b8b-31ab3eaaa695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65f6ab08-cf74-4e52-9b8b-31ab3eaaa695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

