### PR TITLE
Update legacy jwt secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ export $(cat .env.staging | xargs) && python scripts/setup_minio.py
 - `NODE_ENV=production`
 - `MONGODB_URI` (production database)
 - `JWT_SECRET` (strong secret key)
+- `JWT_SECRET_LEGACY` (optional; previous secret to accept old tokens; base64 supported)
 
 ## Configuration & Environment
 
@@ -198,7 +199,7 @@ Key environment variables (see also `docs/secrets.md`):
   - `S3_ENDPOINT`, `S3_REGION`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`
 
 - Legacy API (Express)
-  - `MONGODB_URI`, `JWT_SECRET`, `PORT` (default 5000)
+  - `MONGODB_URI`, `JWT_SECRET`, `JWT_SECRET_LEGACY`, `PORT` (default 5000)
   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `MAIL_FROM`
   - `DISABLE_SLA_MONITOR`, `SLA_MONITOR_INTERVAL_MS`
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,6 +2,7 @@
 
 ## Staging Secret Names
 - SECRET_STAGING_JWT
+- SECRET_STAGING_JWT_LEGACY (optional)
 - SECRET_STAGING_HMAC_LIBRENMS
 - SECRET_STAGING_HMAC_ZABBIX
 - SECRET_STAGING_SENTRY_DSN
@@ -14,6 +15,7 @@
 ## Production Secret Names
 - SECRET_PROD_DATABASE_URL
 - SECRET_PROD_JWT
+- SECRET_PROD_JWT_LEGACY (optional)
 - SECRET_PROD_HMAC_LIBRENMS
 - SECRET_PROD_HMAC_ZABBIX
 - SECRET_PROD_S3_ACCESS_KEY
@@ -28,6 +30,7 @@
 
 ## Guidance
 - JWT and HMAC secrets: generate strong random values (e.g., 32+ bytes hex)
+- For legacy JWT acceptance, set `JWT_SECRET_LEGACY` to your prior secret. If your old secret was stored base64-encoded, it will be tried both as-is and after base64 decoding.
 - S3 access/secret keys: from your object storage/credentials system
 - Sentry DSN: from your Sentry project settings
 - SMTP host/user/pass: from your email provider

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -9,7 +9,26 @@ const auth = async (req, res, next) => {
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret');
+    const primarySecret = process.env.JWT_SECRET || 'fallback_secret';
+    const legacySecretRaw = process.env.JWT_SECRET_LEGACY;
+
+    let decoded;
+    try {
+      decoded = jwt.verify(token, primarySecret);
+    } catch (primaryError) {
+      if (!legacySecretRaw) throw primaryError;
+      // Try legacy secret as-is, then attempt base64-decoded form
+      try {
+        decoded = jwt.verify(token, legacySecretRaw);
+      } catch (legacyError) {
+        try {
+          const maybeB64 = Buffer.from(legacySecretRaw, 'base64').toString('utf8');
+          decoded = jwt.verify(token, maybeB64);
+        } catch (legacyB64Error) {
+          throw primaryError;
+        }
+      }
+    }
     const user = await User.findById(decoded.user.id).select('-password');
     
     if (!user || !user.isActive) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -48,23 +48,31 @@ router.post('/register', [
       }
     };
 
-    jwt.sign(
-      payload,
-      process.env.JWT_SECRET || 'fallback_secret',
-      { expiresIn: '24h' },
-      (err, token) => {
-        if (err) throw err;
-        res.json({ 
-          token,
-          user: {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            role: user.role
-          }
-        });
+    {
+      const primarySecret = process.env.JWT_SECRET;
+      if (!primarySecret && process.env.NODE_ENV === 'production') {
+        return res.status(500).json({ message: 'Server not configured: JWT_SECRET' });
       }
-    );
+      const signingSecret = primarySecret || 'fallback_secret';
+
+      jwt.sign(
+        payload,
+        signingSecret,
+        { algorithm: 'HS256', expiresIn: '24h' },
+        (err, token) => {
+          if (err) throw err;
+          res.json({ 
+            token,
+            user: {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              role: user.role
+            }
+          });
+        }
+      );
+    }
   } catch (error) {
     console.error(error.message);
     res.status(500).send('Server error');
@@ -115,24 +123,32 @@ router.post('/login', [
       }
     };
 
-    jwt.sign(
-      payload,
-      process.env.JWT_SECRET || 'fallback_secret',
-      { expiresIn: '24h' },
-      (err, token) => {
-        if (err) throw err;
-        res.json({ 
-          token,
-          user: {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            role: user.role,
-            lastLogin: user.lastLogin
-          }
-        });
+    {
+      const primarySecret = process.env.JWT_SECRET;
+      if (!primarySecret && process.env.NODE_ENV === 'production') {
+        return res.status(500).json({ message: 'Server not configured: JWT_SECRET' });
       }
-    );
+      const signingSecret = primarySecret || 'fallback_secret';
+
+      jwt.sign(
+        payload,
+        signingSecret,
+        { algorithm: 'HS256', expiresIn: '24h' },
+        (err, token) => {
+          if (err) throw err;
+          res.json({ 
+            token,
+            user: {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              role: user.role,
+              lastLogin: user.lastLogin
+            }
+          });
+        }
+      );
+    }
   } catch (error) {
     console.error(error.message);
     res.status(500).send('Server error');

--- a/supabase/functions/node-express/routes/auth.js
+++ b/supabase/functions/node-express/routes/auth.js
@@ -48,23 +48,31 @@ router.post('/register', [
       }
     };
 
-    jwt.sign(
-      payload,
-      process.env.JWT_SECRET || 'fallback_secret',
-      { expiresIn: '24h' },
-      (err, token) => {
-        if (err) throw err;
-        res.json({ 
-          token,
-          user: {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            role: user.role
-          }
-        });
+    {
+      const primarySecret = process.env.JWT_SECRET;
+      if (!primarySecret && process.env.NODE_ENV === 'production') {
+        return res.status(500).json({ message: 'Server not configured: JWT_SECRET' });
       }
-    );
+      const signingSecret = primarySecret || 'fallback_secret';
+
+      jwt.sign(
+        payload,
+        signingSecret,
+        { algorithm: 'HS256', expiresIn: '24h' },
+        (err, token) => {
+          if (err) throw err;
+          res.json({ 
+            token,
+            user: {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              role: user.role
+            }
+          });
+        }
+      );
+    }
   } catch (error) {
     console.error(error.message);
     res.status(500).send('Server error');
@@ -115,24 +123,32 @@ router.post('/login', [
       }
     };
 
-    jwt.sign(
-      payload,
-      process.env.JWT_SECRET || 'fallback_secret',
-      { expiresIn: '24h' },
-      (err, token) => {
-        if (err) throw err;
-        res.json({ 
-          token,
-          user: {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            role: user.role,
-            lastLogin: user.lastLogin
-          }
-        });
+    {
+      const primarySecret = process.env.JWT_SECRET;
+      if (!primarySecret && process.env.NODE_ENV === 'production') {
+        return res.status(500).json({ message: 'Server not configured: JWT_SECRET' });
       }
-    );
+      const signingSecret = primarySecret || 'fallback_secret';
+
+      jwt.sign(
+        payload,
+        signingSecret,
+        { algorithm: 'HS256', expiresIn: '24h' },
+        (err, token) => {
+          if (err) throw err;
+          res.json({ 
+            token,
+            user: {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              role: user.role,
+              lastLogin: user.lastLogin
+            }
+          });
+        }
+      );
+    }
   } catch (error) {
     console.error(error.message);
     res.status(500).send('Server error');


### PR DESCRIPTION
Add JWT verification fallback for a legacy secret to ensure backward compatibility for existing tokens.

This change allows the system to accept JWTs signed with a previous secret, defined by `JWT_SECRET_LEGACY`, in addition to the primary `JWT_SECRET`. It also updates token signing to explicitly use HS256 and includes a production guard for missing `JWT_SECRET`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e94a0614-4abf-4bb8-b882-ae5c5458098d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e94a0614-4abf-4bb8-b882-ae5c5458098d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

