### PR TITLE
Diagnose serverless function invocation failure

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1,0 +1,71 @@
+// Proxy all /api/* requests to an external backend defined by API_PROXY_TARGET
+// Usage: set Vercel env var API_PROXY_TARGET (e.g., https://your-backend.example.com)
+
+export default async function handler(req, res) {
+  const targetBase = process.env.API_PROXY_TARGET || process.env.FASTAPI_URL || process.env.EXPRESS_URL;
+
+  if (!targetBase) {
+    res.status(500).json({
+      error: "API proxy target is not configured",
+      missing: ["API_PROXY_TARGET"],
+      hint: "Set API_PROXY_TARGET in your Vercel Project Environment to your backend base URL",
+    });
+    return;
+  }
+
+  try {
+    const originalUrl = req.url || "/api";
+    const pathAfterApi = originalUrl.replace(/^\/api\/?/, "");
+
+    // Construct target URL, preserving path and query string
+    const targetUrl = new URL(pathAfterApi || "", targetBase.endsWith("/") ? targetBase : targetBase + "/");
+
+    // Forward headers, excluding hop-by-hop or problematic ones
+    const forwardedHeaders = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value == null) continue;
+      const lower = key.toLowerCase();
+      if (lower === "host" || lower === "content-length" || lower === "accept-encoding") continue;
+      forwardedHeaders[key] = value;
+    }
+
+    let bodyBuffer = undefined;
+    const method = (req.method || "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      bodyBuffer = await new Promise((resolve, reject) => {
+        const chunks = [];
+        req.on("data", (chunk) => chunks.push(chunk));
+        req.on("end", () => resolve(Buffer.concat(chunks)));
+        req.on("error", reject);
+      });
+    }
+
+    const upstreamResponse = await fetch(targetUrl.toString(), {
+      method,
+      headers: forwardedHeaders,
+      // Pass undefined for no-body methods to avoid setting a body accidentally
+      body: bodyBuffer,
+      redirect: "manual",
+    });
+
+    // Copy status and headers
+    res.status(upstreamResponse.status);
+    upstreamResponse.headers.forEach((value, key) => {
+      // Avoid setting content-length explicitly; Node will manage it
+      if (key.toLowerCase() === "content-length") return;
+      res.setHeader(key, value);
+    });
+
+    if (method === "HEAD" || upstreamResponse.status === 204) {
+      res.end();
+      return;
+    }
+
+    const arrayBuffer = await upstreamResponse.arrayBuffer();
+    res.end(Buffer.from(arrayBuffer));
+  } catch (error) {
+    console.error("API proxy error:", error);
+    res.status(502).json({ error: "Bad gateway", detail: String(error && error.message ? error.message : error) });
+  }
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
-  "rewrites": [
-    { "source": "/api/(.*)", "destination": "https://api.example.com/$1" }
+  "version": 2,
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" }
   ]
 }
 


### PR DESCRIPTION
Add a Vercel serverless proxy function and update `vercel.json` to correctly route `/api/*` requests to an external backend, resolving a `FUNCTION_INVOCATION_FAILED` error.

The existing `vercel.json` contained a placeholder rewrite for `/api/*` to `https://api.example.com/$1`, which resulted in a `500: FUNCTION_INVOCATION_FAILED` error because no actual serverless function or valid target was configured. This PR introduces a generic proxy function to forward these requests to a user-defined backend via the `API_PROXY_TARGET` environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c2e65f1-566e-40f3-83ef-f9616a626c72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c2e65f1-566e-40f3-83ef-f9616a626c72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

