### PR TITLE
Proceed to final report due to docker hub limits

### DIFF
--- a/docs/final-report.md
+++ b/docs/final-report.md
@@ -1,0 +1,183 @@
+### Final Report: System Test Blocked by Docker Hub Rate Limiting
+
+- **Date**: 2025-09-11
+- **Repository**: `Smilo-dev2022/kasi-fiber-deployment-management`
+- **Branch**: `cursor/proceed-to-final-report-due-to-docker-hub-limits-ae11`
+- **Commit**: `fd53b9b46c7baadf034abf1767168e83247ee40d`
+- **Status**: System test not executed due to Docker Hub rate limiting on image pulls/builds
+
+### Executive Summary
+- **Outcome**: Full system test could not be run. The API image build failed due to Docker Hub rate limits when pulling the base image `python:3.11-slim`.
+- **Impact**: End-to-end validation of inter-service behavior, deployment readiness, and runtime configuration remains unverified.
+- **Decision**: Proceeding with this report; E2E validation deferred until unblock.
+
+### Project Context
+- **Core API (FastAPI)**: `app/` with health endpoints `/healthz`, `/readyz`.
+- **Legacy API (Node/Express)**: `server/` with routes kept for backward compatibility.
+- **Infra (Compose)**: `infra/docker-compose.yml` defines `db` (PostGIS), `redis`, `minio`, `mailhog`, and `api` service exposing `:8000`.
+
+```1:80:infra/docker-compose.yml
+version: '3.9'
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ../db/init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    env_file:
+      - ../.env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:${POSTGRES_PASSWORD:-change-me}@db:5432/app}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:3000}
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      S3_BUCKET: ${S3_BUCKET:-fiber-photos}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-minio}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-change-me}
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["/bin/bash", "-lc", "uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+volumes:
+  db-data:
+  redis-data:
+  minio-data:
+```
+
+### API Image Build Setup
+The API Dockerfile uses `python:3.11-slim` as the base and installs dependencies from `requirements.txt`.
+
+```1:40:Dockerfile
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# System deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps first for better cache
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy app
+COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./alembic.ini
+COPY scripts ./scripts
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+### Blocker Details
+- **Primary blocker**: Docker Hub rate limit during `docker build` when pulling `python:3.11-slim` (and possibly `redis`, `minio`, `mailhog` images during `compose up`).
+- **Symptom**: HTTP 429 `toomanyrequests`.
+
+Example error:
+```text
+toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
+```
+
+### What Was Attempted
+- Attempted `docker compose -f infra/docker-compose.yml up -d api` and `docker build` for the API image.
+- Retried after cooldowns and authenticated with available credentials.
+- Leveraged local cache where possible. Still blocked by rate limiting.
+
+### Scope Impacted
+- Not executed: Full system test stack with freshly built API image.
+- Not verified: Cross-service contracts, runtime config/env loading, migrations at boot, and E2E flows.
+
+### Partial Validation
+- Unit/integration and non-Docker tasks were prioritized where possible. End-to-end validation remains pending.
+
+### Risks of Proceeding Without System Test
+- **Integration risk**: Contract mismatches between services.
+- **Config/secret risk**: Misconfigured env vars or missing secrets at runtime.
+- **DB/migration risk**: Ordering issues or side effects in production-like runs.
+- **Deployment drift**: Differences between local and CI image builds.
+- **Performance/boot**: Startup regressions not caught by unit/integration tests.
+
+### Unblock Options
+- **Switch base/registry**: Use GHCR/ECR/GCR or a private mirror for `python:3.11-slim` and other images.
+- **Configure daemon mirror** (e.g., `mirror.gcr.io`) to reduce Hub pulls.
+- **Preload base images** via `docker save`/`load` on systems that already have them.
+- **BuildKit cache**: Use `buildx` with local or remote cache to avoid repeated pulls.
+- **Paid Docker Hub**: Authenticate with higher pull limits.
+- **CI-built image**: Build in CI where limits are higher; then `compose pull` locally.
+
+### Minimal Post-Unblock Test Plan
+1) Build API image:
+```bash
+docker buildx build -t local/fastapi-api:local --pull .
+```
+2) Start stack:
+```bash
+docker compose -f infra/docker-compose.yml up -d
+docker compose -f infra/docker-compose.yml logs -f api | cat
+```
+3) Health checks:
+```bash
+curl -fsS http://localhost:8000/healthz
+curl -fsS http://localhost:8000/readyz
+```
+4) Exercise key routes used by other services.
+5) Run `alembic upgrade head` if not executed automatically.
+
+### Environment References
+- See `README.md` for environment variables (`DATABASE_URL`, `CORS_ALLOW_ORIGINS`, `S3_*`, rate limits, etc.).
+
+### Reviewer Notes
+- This failure appears environmental (registry rate limits) rather than a code defect.
+- The above unblock steps are standard and low-risk where alternative registries or CI access exists.
+


### PR DESCRIPTION
Create `docs/final-report.md` to document the inability to run system tests due to Docker Hub rate limits and provide unblock options and a minimal post-unblock test plan.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bc2798e-e20a-4825-9cf1-d8aec7838f04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bc2798e-e20a-4825-9cf1-d8aec7838f04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

